### PR TITLE
Fix for bug where events could not be deleted by ID

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -221,7 +221,7 @@ function Scheduler(connection, options = {}) {
       }
       
       if (objectId.isValid(id)) {
-        event._id = id;
+        event._id = new mongo.ObjectID(id);
       }
       
       if (typeof after === 'string') {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -221,7 +221,7 @@ function Scheduler(connection, options = {}) {
       }
       
       if (objectId.isValid(id)) {
-        event._id = objectID(id);
+        event._id = objectId(id);
       }
       
       if (typeof after === 'string') {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -221,7 +221,7 @@ function Scheduler(connection, options = {}) {
       }
       
       if (objectId.isValid(id)) {
-        event._id = new mongo.ObjectID(id);
+        event._id = objectID(id);
       }
       
       if (typeof after === 'string') {


### PR DESCRIPTION
This fixes #4 .
The problem was `event._id` must be of type `mongo.ObjectID`.