### PR TITLE
fixing scheduler.remove()

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -274,7 +274,7 @@ function Scheduler(connection, options = {}) {
       const query      = {};
       
       if (typeof name === 'string') {
-        query.event = name;
+        query.name = name;
       }
       
       if (objectId.isValid(id)) {


### PR DESCRIPTION
There's a bug that hinders `scheduler.remove()` from working.

```
if (typeof name === 'string') {
   query.event = name;
}
```

needs to be 
```
if (typeof name === 'string') {
   query.name = name;
}
```