### PR TITLE
Fix Codacy Coverage

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -43,9 +43,3 @@ jobs:
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
         coverage-reports: coverage/lcov.info
-
-    - if: (matrix.node-version == '15.x' && matrix.mongodb-version == 4.4)
-      uses: actions/upload-artifact@v2
-      with:
-        name: coverage-file
-        path: ${{ github.workspace }}/coverage/lcov.info

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -36,26 +36,16 @@ jobs:
     - run: npm ci && npm i -g projectz badges
     - run: npm run build --if-present
     - run: npm run test:coverage
-    
+
+    - name: Run codacy-coverage-reporter
+      if: (matrix.node-version == '15.x' && matrix.mongodb-version == 4.4)
+      uses: codacy/codacy-coverage-reporter-action@master
+      with:
+        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        coverage-reports: coverage/lcov.info
+
     - if: (matrix.node-version == '15.x' && matrix.mongodb-version == 4.4)
       uses: actions/upload-artifact@v2
       with:
         name: coverage-file
         path: ${{ github.workspace }}/coverage/lcov.info
-      
-#   upload-coverage:
-#     runs-on: ubuntu-latest
-#     needs: [build]
-    
-# #     if: job.
- 
-#     steps:
-#     - uses: actions/download-artifact@v2
-#       with:
-#         name: coverage-file
-
-#     - name: Run codacy-coverage-reporter
-#       uses: codacy/codacy-coverage-reporter-action@master
-#       with:
-#         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-#         coverage-reports: lcov.info


### PR DESCRIPTION
It fails in CI because secrets aren't passed to forks

Tested [here](https://github.com/darkterra/mongo-scheduler/runs/1643860807?check_suite_focus=true#step:10:34)